### PR TITLE
Breakup SparkFunSuite and SparkIntegrationFunSuite

### DIFF
--- a/lighthouse-testing/src/main/scala/be/dataminded/lighthouse/testing/SparkFunSuite.scala
+++ b/lighthouse-testing/src/main/scala/be/dataminded/lighthouse/testing/SparkFunSuite.scala
@@ -10,13 +10,16 @@ case object SparkIntegrationTest extends Tag("be.dataminded.lighthouse.testing.S
   */
 class SparkFunSuite extends FunSuite with SharedSparkSession {
 
-  def sparkTest(name: String)(body: => Unit): Unit = {
+  def test(name: String)(body: => Unit): Unit = {
     test(name, SparkTest) {
       body
     }
   }
+}
 
-  def sparkIntegrationTest(name: String)(body: => Unit): Unit = {
+class SparkIntegrationFunSuite extends FunSuite with SharedSparkSession {
+
+  def test(name: String)(body: => Unit): Unit = {
     test(name, SparkIntegrationTest) {
       body
     }

--- a/lighthouse-testing/src/test/scala/be/dataminded/lighthouse/testing/SparkFunSuiteTest.scala
+++ b/lighthouse-testing/src/test/scala/be/dataminded/lighthouse/testing/SparkFunSuiteTest.scala
@@ -4,11 +4,14 @@ import org.scalatest.Matchers
 
 class SparkFunSuiteTest extends SparkFunSuite with Matchers {
 
-  sparkTest("A SparkTest has an instance of SparkSession available") {
+  test("A SparkTest has an instance of SparkSession available") {
     assertCompiles("spark")
   }
+}
 
-  sparkIntegrationTest("A SparkIntegrationTest has an instance of SparkSession available") {
+class SparkIntegartionFunSuiteTest extends SparkIntegrationFunSuite with Matchers {
+
+  test("A SparkIntegrationTest has an instance of SparkSession available") {
     assertCompiles("spark")
   }
 }


### PR DESCRIPTION
The number of times where you want to mix and match tests and integration tests in the same class seems very low to me.

Anyway, by having a method named "test" the IDE (intellij idea in particular) becomes much better, as you can now hover over a specific test and run that specific one..