### PR TITLE
Feature/specify schema on read

### DIFF
--- a/lighthouse-core/src/main/scala/be/dataminded/lighthouse/datalake/FileSystemDataLink.scala
+++ b/lighthouse-core/src/main/scala/be/dataminded/lighthouse/datalake/FileSystemDataLink.scala
@@ -1,6 +1,7 @@
 package be.dataminded.lighthouse.datalake
 
 import be.dataminded.lighthouse.spark.{Orc, SparkFileFormat}
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Dataset, SaveMode}
 
 /**
@@ -16,10 +17,16 @@ class FileSystemDataLink(val path: LazyConfig[String],
                          format: SparkFileFormat = Orc,
                          saveMode: SaveMode = SaveMode.Overwrite,
                          partitionedBy: List[String] = List.empty,
-                         options: Map[String, String] = Map.empty)
+                         options: Map[String, String] = Map.empty,
+                         schema: Option[StructType] = None)
     extends PathBasedDataLink {
 
-  override def doRead(path: String): DataFrame = spark.read.format(format.toString).options(options).load(path)
+  override def doRead(path: String): DataFrame = {
+    schema match {
+      case Some(s) => spark.read.format(format.toString).options(options).schema(s).load(path)
+      case None    => spark.read.format(format.toString).options(options).load(path)
+    }
+  }
 
   override def doWrite[T](dataset: Dataset[T], path: String): Unit = {
     dataset.write

--- a/lighthouse-core/src/test/scala/be/dataminded/lighthouse/datalake/DatalakeTest.scala
+++ b/lighthouse-core/src/test/scala/be/dataminded/lighthouse/datalake/DatalakeTest.scala
@@ -14,7 +14,7 @@ class DatalakeTest extends FunSuite with Matchers {
     dataRef should equal(datalake.testRef)
   }
 
-  test("A datalake can also retrieve properties through it's appy method") {
+  test("A datalake can retrieve properties through its apply method") {
     val dataRef = datalake(datalake.uid)
 
     dataRef should equal(datalake.testRef)

--- a/lighthouse-core/src/test/scala/be/dataminded/lighthouse/datalake/FileSystemDataLinkTest.scala
+++ b/lighthouse-core/src/test/scala/be/dataminded/lighthouse/datalake/FileSystemDataLinkTest.scala
@@ -7,6 +7,7 @@ import be.dataminded.lighthouse.Models
 import be.dataminded.lighthouse.spark.Csv
 import be.dataminded.lighthouse.testing.SparkFunSuite
 import better.files._
+import org.apache.spark.sql.types._
 import org.scalatest.{BeforeAndAfter, Matchers}
 
 class FileSystemDataLinkTest extends SparkFunSuite with Matchers with BeforeAndAfter {
@@ -27,6 +28,19 @@ class FileSystemDataLinkTest extends SparkFunSuite with Matchers with BeforeAndA
     val dataset = link.readAs[Models.RawCustomer]()
 
     dataset.count should equal(3)
+  }
+
+  test("A FileSystemDataLink can leverage a specified schema") {
+    val schema = Option(
+      StructType(
+        StructField("id", ByteType) ::
+          StructField("firstName", StringType, nullable = true) ::
+          StructField("lastName", StringType, nullable = true) ::
+          StructField("yearOfBirth", ShortType, nullable = true) :: Nil))
+    val link    = new FileSystemDataLink(path = customerPath, format = Csv, options = options, schema = schema)
+    val dataset = link.read()
+
+    dataset.schema should equal(schema.get)
   }
 
   test("A FileSystemDataLink can be used to write a DataFrame") {


### PR DESCRIPTION
In this PR, I add the option to specify the schema of certain fileformats (e.g. JSON, CSV) upon reading, thereby preventing a double-pass. The underlying work is still done by Spark. The approach differs from Spark in the sense that the schema is an `Option[StructType]`, rather than just `StructType`.

Also corrected some spelling.