### PR TITLE
Added functionality to overwrite multiple partitions in Hive table

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ lazy val buildSettings = Seq(
     "-Dspark.shuffle.sort.bypassMergeThreshold=2",
     "-Dlighthouse.environment=test"
   ),
-  scalacOptions ++= Seq("-Ypartial-unification", "-Ywarn-value-discard"),
+  scalacOptions ++= Seq("-Ypartial-unification"),
   // Git versioning
   git.useGitDescribe := true,
   git.baseVersion := "0.0.0",

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -16,13 +16,13 @@ Start by adding the Lighthouse dependency to your project. In case you are using
 <dependency>
     <groupId>be.dataminded</groupId>
     <artifactId>lighthouse_2.11</artifactId>
-    <version>0.2.0</version>
+    <version>0.2.5</version>
 </dependency>
 ```
 or sbt:
 
 ```scala
-libraryDependencies += "be.dataminded" % "lighthouse" %% "0.2.0"
+libraryDependencies += "be.dataminded" %% "lighthouse" % "0.2.5"
 ```
 You can also manually clone and build Lighthouse. You can get the repo here:
 ```
@@ -228,4 +228,4 @@ Note that this time, we made it a `HiveDataLink` and we store it in the table `a
 
  
 ### Demo
-You can find the full source code of this example in the `lighthouse-demo` folder of the Lighthouse repository. [Unit tests](https://github.com/datamindedbe/lighthouse/tree/master/lighthouse-core/src/test) are available to show how each aspect is supposed to work, on your own machine. As Lighthouse is just a Spark library, you can deploy it in your normal deployment pipeline, you cen include it in your jar, and simply submit Spark jobs to your cluster. 
+You can find the full source code of this example in the `lighthouse-demo` folder of the Lighthouse repository. [Unit tests](https://github.com/datamindedbe/lighthouse/tree/master/lighthouse-core/src/test) are available to show how each aspect is supposed to work, on your own machine. As Lighthouse is just a Spark library, you can deploy it in your normal deployment pipeline, you can include it in your jar, and simply submit Spark jobs to your cluster. 

--- a/lighthouse-core/src/main/scala/be/dataminded/lighthouse/datalake/HiveDataLink.scala
+++ b/lighthouse-core/src/main/scala/be/dataminded/lighthouse/datalake/HiveDataLink.scala
@@ -39,7 +39,7 @@ class HiveDataLink(val path: LazyConfig[String],
     (saveMode, overwriteBehavior) match {
       // Only overwrite a single partition in this case
       case (SaveMode.Overwrite, PartitionOverwrite) =>
-        // TODO: Do we need it since spark 2.3.0? See MultiplePartitionOverwrite
+        // It works fine with Spark below 2.3.0
         // Extract the base path based on the full path and partitionedBy information. Ordering matters!
         val basePath = partitionedBy.reverse.foldLeft(path.trim().stripSuffix("/")) {
           case (p, ptn) => p.substring(0, p.lastIndexOf(ptn)).trim().stripSuffix("/")

--- a/lighthouse-core/src/main/scala/be/dataminded/lighthouse/spark/SparkOverwriteBehavior.scala
+++ b/lighthouse-core/src/main/scala/be/dataminded/lighthouse/spark/SparkOverwriteBehavior.scala
@@ -3,14 +3,16 @@ package be.dataminded.lighthouse.spark
 /**
   * Type-safe objects to express partition overwrite behavior
   */
-sealed trait SparkOverwriteBehavior {
-  val name: String
+sealed abstract class SparkOverwriteBehavior(name: String) {
   override def toString: String = name
 }
 
-case object FullOverwrite extends SparkOverwriteBehavior { val name = "FullOverwrite" }
+object SparkOverwriteBehavior {
 
-case object PartitionOverwrite extends SparkOverwriteBehavior { val name = "PartitionOverwrite" }
+  case object FullOverwrite extends SparkOverwriteBehavior("FullOverwrite")
 
-case object MultiplePartitionOverwrite extends SparkOverwriteBehavior { val name = "MultiplePartitionOverwrite" }
+  case object PartitionOverwrite extends SparkOverwriteBehavior("PartitionOverwrite")
 
+  case object MultiplePartitionOverwrite extends SparkOverwriteBehavior("MultiplePartitionOverwrite")
+
+}

--- a/lighthouse-core/src/main/scala/be/dataminded/lighthouse/spark/SparkOverwriteBehavior.scala
+++ b/lighthouse-core/src/main/scala/be/dataminded/lighthouse/spark/SparkOverwriteBehavior.scala
@@ -11,3 +11,6 @@ sealed trait SparkOverwriteBehavior {
 case object FullOverwrite extends SparkOverwriteBehavior { val name = "FullOverwrite" }
 
 case object PartitionOverwrite extends SparkOverwriteBehavior { val name = "PartitionOverwrite" }
+
+case object MultiplePartitionOverwrite extends SparkOverwriteBehavior { val name = "MultiplePartitionOverwrite" }
+

--- a/lighthouse-core/src/main/scala/be/dataminded/lighthouse/spark/SparkSessions.scala
+++ b/lighthouse-core/src/main/scala/be/dataminded/lighthouse/spark/SparkSessions.scala
@@ -17,7 +17,8 @@ trait SparkSessions {
     "spark.serializer"                                       -> "org.apache.spark.serializer.KryoSerializer",
     "spark.sql.avro.compression.codec"                       -> "snappy",
     "spark.sql.parquet.compression.codec"                    -> "snappy",
-    "spark.sql.sources.partitionColumnTypeInference.enabled" -> "false"
+    "spark.sql.sources.partitionColumnTypeInference.enabled" -> "false",
+    "spark.sql.sources.partitionOverwriteMode"               -> "dynamic"
   )
 
   lazy val spark: SparkSession =

--- a/lighthouse-core/src/test/scala/be/dataminded/lighthouse/datalake/HiveDataLinkTest.scala
+++ b/lighthouse-core/src/test/scala/be/dataminded/lighthouse/datalake/HiveDataLinkTest.scala
@@ -60,12 +60,6 @@ class HiveDataLinkTest extends SparkFunSuite with Matchers with BeforeAndAfter {
     ).toDF()
 
     ref.write(updating)
-    //debug
-    ref.readAs[Models.RawCustomer]().show()
-    println("Current Spark version: " + spark.version)
-    println("Current partitionOverwriteMode value: " + spark.conf.get("spark.sql.sources.partitionOverwriteMode"))
-    //debug
-
     ref.readAs[Models.RawCustomer].count should equal(2)
 
     val expected = Seq(

--- a/lighthouse-core/src/test/scala/be/dataminded/lighthouse/datalake/HiveDataLinkTest.scala
+++ b/lighthouse-core/src/test/scala/be/dataminded/lighthouse/datalake/HiveDataLinkTest.scala
@@ -60,15 +60,14 @@ class HiveDataLinkTest extends SparkFunSuite with Matchers with BeforeAndAfter {
     ).toDF()
 
     ref.write(updating)
-    ref.readAs[Models.RawCustomer].count should equal(2)
+    ref.readAs[Models.RawCustomer]().count should equal(2)
 
     val expected = Seq(
       Models.RawCustomer("4", "Kate", "Middleton", "1982"),
       Models.RawCustomer("3", "Donald", "Glover", "1983")
     )
 
-    import spark.implicits._
-    ref.readAs[Models.RawCustomer].collect() should contain theSameElementsAs expected
+    ref.readAs[Models.RawCustomer]().collect() should contain theSameElementsAs expected
 
     //TODO: Result is correct, matcher fails: investigate
     //spark.catalog.listTables().collect() should contain (new org.apache.spark.sql.catalog.Table(

--- a/lighthouse-core/src/test/scala/be/dataminded/lighthouse/datalake/HiveDataLinkTest.scala
+++ b/lighthouse-core/src/test/scala/be/dataminded/lighthouse/datalake/HiveDataLinkTest.scala
@@ -1,8 +1,10 @@
 package be.dataminded.lighthouse.datalake
 
 import be.dataminded.lighthouse.Models
+import be.dataminded.lighthouse.spark.{MultiplePartitionOverwrite, Orc, SparkFileFormat, SparkOverwriteBehavior}
 import be.dataminded.lighthouse.testing.SparkFunSuite
 import better.files._
+import org.apache.spark.sql.SaveMode
 import org.scalatest.{BeforeAndAfter, Matchers}
 
 class HiveDataLinkTest extends SparkFunSuite with Matchers with BeforeAndAfter {
@@ -30,6 +32,53 @@ class HiveDataLinkTest extends SparkFunSuite with Matchers with BeforeAndAfter {
     ref.write(dataset)
 
     ref.read().count should equal(1)
+    //TODO: Result is correct, matcher fails: investigate
+    //spark.catalog.listTables().collect() should contain (new org.apache.spark.sql.catalog.Table(
+    //name = "customer", database = "default", description = null, tableType = "EXTERNAL", isTemporary = false))
+  }
+
+  test("Overwrite multiple partitions") {
+    import spark.implicits._
+    val dataset = Seq(
+      Models.RawCustomer("1", "Pascal", "Knapen", "1982"),
+      Models.RawCustomer("2", "Elisabeth", "Moss", "1982"),
+      Models.RawCustomer("3", "Donald", "Glover", "1983")
+    ).toDF()
+
+    val ref     = new HiveDataLink(
+      path = "./target/output/orc",
+      database = "default",
+      table = "customer",
+      format = Orc,
+      saveMode = SaveMode.Overwrite,
+      partitionedBy =  List("yearOfBirth"),
+      overwriteBehavior = MultiplePartitionOverwrite,
+      options = Map.empty)
+
+    ref.write(dataset)
+    ref.readAs[Models.RawCustomer].count should equal(3)
+
+    val updating = Seq(
+      Models.RawCustomer("4", "Kate", "Middleton", "1982")
+    ).toDF()
+
+    ref.write(updating)
+    //debug
+    ref.readAs[Models.RawCustomer].collect().foreach(println)
+    println("Current Spark version: " + spark.version)
+    println("Current partitionOverwriteMode value: " + spark.conf.get("spark.sql.sources.partitionOverwriteMode"))
+    //debug
+
+    ref.readAs[Models.RawCustomer].count should equal(2)
+
+    val expected = Seq(
+      Models.RawCustomer("4", "Kate", "Middleton", "1982"),
+      Models.RawCustomer("3", "Donald", "Glover", "1983")
+    )
+
+    import spark.implicits._
+    ref.readAs[Models.RawCustomer].collect() should contain theSameElementsAs expected
+
     //TODO: Result is correct, matcher fails: investigate
     //spark.catalog.listTables().collect() should contain (new org.apache.spark.sql.catalog.Table(
     //name = "customer", database = "default", description = null, tableType = "EXTERNAL", isTemporary = false))

--- a/lighthouse-testing/src/main/scala/be/dataminded/lighthouse/testing/SharedSparkSession.scala
+++ b/lighthouse-testing/src/main/scala/be/dataminded/lighthouse/testing/SharedSparkSession.scala
@@ -27,6 +27,7 @@ trait SharedSparkSession {
     .config("spark.sql.avro.compression.codec", "snappy")
     .config("spark.sql.parquet.compression.codec", "snappy")
     .config("spark.ui.enabled", "false")
+    .config("spark.sql.sources.partitionOverwriteMode", "dynamic")
     .enableHiveSupport()
     .getOrCreate()
 }


### PR DESCRIPTION
This feature requires Spark 2.3.0 and above.

Implementing this feature https://issues.apache.org/jira/browse/SPARK-20236 in Lighthouse. 
If we have Hive table partitioned by Year with the following data:
Models.RawCustomer("1", "Pascal", "Knapen", "1982"),
Models.RawCustomer("2", "Elisabeth", "Moss", "1982"),
Models.RawCustomer("3", "Donald", "Glover", "1983")

Then receive new data Dataset:
Models.RawCustomer("4", "Kate", "Middleton", "1982")

And want to overwrite all partitions that exists in the new Dataset (1982 in our case) to get:
Models.RawCustomer("4", "Kate", "Middleton", "1982"),
Models.RawCustomer("3", "Donald", "Glover", "1983")

To do this now we can specify create new HiveDataLink;
val ref = new HiveDataLink (
      ...
      partitionedBy = List("yearOfBirth"),
      overwriteBehavior = MultiplePartitionOverwrite
    )
and then use write method
ref.write(updating)



