### PR TITLE
Update Spark version to 2.4.4, other libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,8 @@ lazy val buildSettings = Seq(
     "-optimize",
     "-unchecked",
     "-Ydelambdafy:inline",
-    "-Ypartial-unification"
+    "-Ypartial-unification",
+    "-Ywarn-unused-import"
   ),
   // Git versioning
   git.useGitDescribe := true,

--- a/lighthouse-core/src/main/scala/be/dataminded/lighthouse/datalake/JdbcDataLink.scala
+++ b/lighthouse-core/src/main/scala/be/dataminded/lighthouse/datalake/JdbcDataLink.scala
@@ -3,7 +3,6 @@ package be.dataminded.lighthouse.datalake
 import be.dataminded.lighthouse.common.Database
 import org.apache.spark.sql.{DataFrame, Dataset, SaveMode}
 
-import scala.language.implicitConversions
 import scala.util.{Failure, Success, Try}
 
 /**

--- a/lighthouse-core/src/main/scala/be/dataminded/lighthouse/pipeline/RichSparkFunctions.scala
+++ b/lighthouse-core/src/main/scala/be/dataminded/lighthouse/pipeline/RichSparkFunctions.scala
@@ -4,7 +4,6 @@ import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.sql.{Dataset, Encoder}
 import org.apache.spark.storage.StorageLevel
 
-import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
 object RichSparkFunctions extends LazyLogging {

--- a/lighthouse-core/src/main/scala/be/dataminded/lighthouse/pipeline/SparkFunction.scala
+++ b/lighthouse-core/src/main/scala/be/dataminded/lighthouse/pipeline/SparkFunction.scala
@@ -6,7 +6,7 @@ import org.apache.spark.sql.SparkSession
 
 trait SparkFunction[+A] {
 
-  def run(spark: SparkSession): (A)
+  def run(spark: SparkSession): A
 
   // Enables the box, map, flatMap and for-comprehension support
   def map[B](f: A => B): SparkFunction[B] = monad.map(this)(f)

--- a/lighthouse-core/src/test/scala/be/dataminded/lighthouse/common/DatabaseTest.scala
+++ b/lighthouse-core/src/test/scala/be/dataminded/lighthouse/common/DatabaseTest.scala
@@ -1,8 +1,9 @@
 package be.dataminded.lighthouse.common
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class DatabaseTest extends FunSpec with Matchers {
+class DatabaseTest extends AnyFunSpec with Matchers {
 
   describe("An in-memory database") {
 

--- a/lighthouse-core/src/test/scala/be/dataminded/lighthouse/common/DateTimeFormattersTest.scala
+++ b/lighthouse-core/src/test/scala/be/dataminded/lighthouse/common/DateTimeFormattersTest.scala
@@ -3,9 +3,10 @@ package be.dataminded.lighthouse.common
 import java.time.LocalDate
 
 import be.dataminded.lighthouse.common.DateTimeFormatters._
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class DateTimeFormattersTest extends FunSuite with Matchers {
+class DateTimeFormattersTest extends AnyFunSuite with Matchers {
 
   test("Simple Date Format should format a date like yyyy/MM/dd") {
     val result = SimpleDateFormat.format(LocalDate.of(1990, 1, 1))

--- a/lighthouse-core/src/test/scala/be/dataminded/lighthouse/common/FileSystemTest.scala
+++ b/lighthouse-core/src/test/scala/be/dataminded/lighthouse/common/FileSystemTest.scala
@@ -2,13 +2,14 @@ package be.dataminded.lighthouse.common
 
 import java.nio.file.NoSuchFileException
 
-import better.files.File
-import org.scalatest.{FunSuite, Matchers}
+import better.files.Resource
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class FileSystemTest extends FunSuite with Matchers {
+class FileSystemTest extends AnyFunSuite with Matchers {
 
   test("Can read a file as a string") {
-    val content = FileSystem.read(File.resource("customers.csv").pathAsString)
+    val content = FileSystem.read(Resource.getUrl("customers.csv").getPath())
     content should not be empty
   }
 

--- a/lighthouse-core/src/test/scala/be/dataminded/lighthouse/config/LighthouseConfigurationParserTest.scala
+++ b/lighthouse-core/src/test/scala/be/dataminded/lighthouse/config/LighthouseConfigurationParserTest.scala
@@ -3,9 +3,11 @@ package be.dataminded.lighthouse.config
 import java.time.LocalDate
 
 import be.dataminded.lighthouse.datalake.Datalake
-import org.scalatest.{BeforeAndAfterEach, FunSuite, Matchers}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class LighthouseConfigurationParserTest extends FunSuite with Matchers with BeforeAndAfterEach {
+class LighthouseConfigurationParserTest extends AnyFunSuite with Matchers with BeforeAndAfterEach {
 
   val parser = new LighthouseConfigurationParser()
 

--- a/lighthouse-core/src/test/scala/be/dataminded/lighthouse/datalake/DatalakeTest.scala
+++ b/lighthouse-core/src/test/scala/be/dataminded/lighthouse/datalake/DatalakeTest.scala
@@ -2,11 +2,13 @@ package be.dataminded.lighthouse.datalake
 
 import java.time.{LocalDate, Month}
 
-import org.scalatest.{FunSuite, Matchers, PrivateMethodTester}
+import org.scalatest.PrivateMethodTester
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class DatalakeTest extends FunSuite with Matchers with PrivateMethodTester {
+class DatalakeTest extends AnyFunSuite with Matchers with PrivateMethodTester {
 
-  val datalake = new SampleDatalake()
+  private[this] val datalake = new SampleDatalake()
 
   test("A datalake uses the `test` environment by default") {
     val dataRef = datalake.getDataLink(datalake.uid)
@@ -65,10 +67,10 @@ class DatalakeTest extends FunSuite with Matchers with PrivateMethodTester {
 /**
   * Use a class here to make the tests run in isolation
   */
-class SampleDatalake(executionDate: LocalDate = LocalDate.now()) extends Datalake {
+private class SampleDatalake(executionDate: LocalDate = LocalDate.now()) extends Datalake {
 
-  val uid         = DataUID("datamined", "key")
-  val snapshotUID = DataUID("datamined", "snapshotkey")
+  val uid: DataUID         = DataUID("datamined", "key")
+  val snapshotUID: DataUID = DataUID("datamined", "snapshotkey")
 
   val testRef = new HiveDataLink("s3://test", table = "test", database = "test")
   val accRef  = new HiveDataLink("s3://acc", table = "acc", database = "acc")

--- a/lighthouse-core/src/test/scala/be/dataminded/lighthouse/datalake/FileSystemDataLinkTest.scala
+++ b/lighthouse-core/src/test/scala/be/dataminded/lighthouse/datalake/FileSystemDataLinkTest.scala
@@ -8,14 +8,15 @@ import be.dataminded.lighthouse.spark.Csv
 import be.dataminded.lighthouse.testing.SparkFunSuite
 import better.files._
 import org.apache.spark.sql.types._
-import org.scalatest.{BeforeAndAfter, Matchers}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.matchers.should.Matchers
 
 class FileSystemDataLinkTest extends SparkFunSuite with Matchers with BeforeAndAfter {
 
   import spark.implicits._
 
-  val customerPath: String = File.resource("customers.csv").pathAsString
-  val ordersPath: String   = File.resource("orders.csv").pathAsString
+  val customerPath: String = Resource.getUrl("customers.csv").getPath()
+  val ordersPath: String   = Resource.getUrl("orders.csv").getPath()
   val options              = Map("header" -> "true")
 
   test("A FileSystemDataLink can read a DataFrame from a local file") {
@@ -76,6 +77,6 @@ class FileSystemDataLinkTest extends SparkFunSuite with Matchers with BeforeAndA
   }
 
   after {
-    file"target/output".delete(true)
+    file"target/output".delete(swallowIOExceptions = true)
   }
 }

--- a/lighthouse-core/src/test/scala/be/dataminded/lighthouse/datalake/HiveDataLinkTest.scala
+++ b/lighthouse-core/src/test/scala/be/dataminded/lighthouse/datalake/HiveDataLinkTest.scala
@@ -1,5 +1,7 @@
 package be.dataminded.lighthouse.datalake
 
+import java.io.File
+import java.sql.Date
 import java.time.LocalDate
 import java.time.Month.DECEMBER
 
@@ -7,76 +9,84 @@ import be.dataminded.lighthouse.Models
 import be.dataminded.lighthouse.spark.SparkOverwriteBehavior._
 import be.dataminded.lighthouse.testing.SparkFunSuite
 import better.files._
-import org.apache.spark.sql.SaveMode
-import org.scalatest.{BeforeAndAfterEach, Matchers}
+import org.apache.spark.sql.catalog.Table
+import org.apache.spark.sql.functions._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.should.Matchers
 
 class HiveDataLinkTest extends SparkFunSuite with Matchers with BeforeAndAfterEach {
+  import spark.implicits._
 
-  val customerPath: String = File.resource("customers.csv").pathAsString
-  val ordersPath: String   = File.resource("orders.csv").pathAsString
-  val options              = Map("header" -> "true")
+  private[this] val expectedTable = new Table(
+    name = "customer",
+    database = "default",
+    description = null,
+    tableType = "EXTERNAL",
+    isTemporary = false
+  )
 
   test("A hive data reference can be used to write a dataset") {
-    import spark.implicits._
     val dataset = Seq(Models.RawCustomer("1", "Pascal", "Knapen", "1982")).toDS()
     val ref     = new HiveDataLink(path = "./target/output/orc", database = "default", table = "customer")
-    ref.write(dataset)
 
-    ref.readAs[Models.RawCustomer]().count should equal(1)
-    //TODO: Result is correct, matcher fails: investigate
-    //spark.catalog.listTables().collect() should contain (new org.apache.spark.sql.catalog.Table(
-    //name = "customer", database = "default", description = null, tableType = "EXTERNAL", isTemporary = false))
+    ref.write(dataset)
+    val actualTable = spark.catalog.listTables().filter(_.name == "customer").head()
+
+    ref.read().count should equal(1)
+    actualTable.toString() shouldBe expectedTable.toString()
   }
 
   test("A hive datalink can be used in overwrite mode") {
-
-    import spark.implicits._
-    val filePath = "./target/output/orc"
-    import org.apache.spark.sql.functions._
-    val saveMode    = SaveMode.Overwrite
     val ingestDate1 = LocalDate.of(1982, DECEMBER, 21)
+    val ingestDate2 = LocalDate.of(1982, DECEMBER, 22)
+    val filePath    = "./target/output/orc"
+    val rootFile    = new File(filePath)
+
     val dataset1 = Seq(Models.RawCustomer("1", "Pascal", "Knapen", "1982"))
       .toDS()
-      .withColumn("ingestDate", lit(java.sql.Date.valueOf(ingestDate1)))
-    val ref =
-      new HiveDataLink(path = filePath, database = "default", table = "customer", partitionedBy = List("ingestDate"))
-    ref.snapshotOf(LocalDate.of(1982, DECEMBER, 21))
-    ref.write(dataset1)
-    ref.readAs[Models.RawCustomer]().count should equal(1)
-    val rootFile = new java.io.File(filePath)
-    rootFile.listFiles.filter(_.isDirectory).toList should
-      (contain(new java.io.File(s"$filePath/ingestDate=1982-12-21")) and have length 1)
-
-    val ingestDate2 = LocalDate.of(1982, DECEMBER, 22)
+      .withColumn("ingestDate", lit(Date.valueOf(ingestDate1)))
     val dataset2 = Seq(Models.RawCustomer("2", "Elisabeth", "Moss", "1982"))
       .toDS()
-      .withColumn("ingestDate", lit(java.sql.Date.valueOf(ingestDate2)))
+      .withColumn("ingestDate", lit(Date.valueOf(ingestDate2)))
+    val ref =
+      new HiveDataLink(path = filePath, database = "default", table = "customer", partitionedBy = List("ingestDate"))
+
+    ref.snapshotOf(ingestDate1)
+    ref.write(dataset1)
+    ref.read().count should equal(1)
+    rootFile.listFiles.filter(_.isDirectory).toList should
+      (contain(new File(s"$filePath/ingestDate=1982-12-21")) and have length 1)
 
     ref.write(dataset2)
-    ref.readAs[Models.RawCustomer]().count should equal(2)
+    ref.read().count should equal(2)
     rootFile.listFiles.filter(_.isDirectory).toList should
-      (contain(new java.io.File(s"$filePath/ingestDate=1982-12-22")) and have length 2)
+      (contain(new File(s"$filePath/ingestDate=1982-12-22")) and have length 2)
   }
 
   test("A hive data reference can be used to write a dataframe") {
-    import spark.implicits._
     val dataset = Seq(Models.RawCustomer("1", "Pascal", "Knapen", "1982")).toDF()
     val ref     = new HiveDataLink(path = "./target/output/orc", database = "default", table = "customer")
+
     ref.write(dataset)
+    val actualTable = spark.catalog.listTables().filter(_.name == "customer").head()
 
     ref.read().count should equal(1)
-    //TODO: Result is correct, matcher fails: investigate
-    //spark.catalog.listTables().collect() should contain (new org.apache.spark.sql.catalog.Table(
-    //name = "customer", database = "default", description = null, tableType = "EXTERNAL", isTemporary = false))
+    actualTable.toString() shouldBe expectedTable.toString()
   }
 
   test("Overwrite multiple partitions") {
-    import spark.implicits._
     val dataset = Seq(
       Models.RawCustomer("1", "Pascal", "Knapen", "1982"),
       Models.RawCustomer("2", "Elisabeth", "Moss", "1982"),
       Models.RawCustomer("3", "Donald", "Glover", "1983")
     ).toDF()
+    val updating = Seq(
+      Models.RawCustomer("4", "Kate", "Middleton", "1982")
+    ).toDF()
+    val expected = Seq(
+      Models.RawCustomer("4", "Kate", "Middleton", "1982"),
+      Models.RawCustomer("3", "Donald", "Glover", "1983")
+    )
 
     val ref = new HiveDataLink(
       path = "./target/output/orc",
@@ -87,25 +97,15 @@ class HiveDataLinkTest extends SparkFunSuite with Matchers with BeforeAndAfterEa
     )
 
     ref.write(dataset)
-    ref.readAs[Models.RawCustomer]().count should equal(3)
-
-    val updating = Seq(
-      Models.RawCustomer("4", "Kate", "Middleton", "1982")
-    ).toDF()
+    ref.read().count should equal(3)
 
     ref.write(updating)
-    ref.readAs[Models.RawCustomer]().count should equal(2)
+    ref.read().count should equal(2)
 
-    val expected = Seq(
-      Models.RawCustomer("4", "Kate", "Middleton", "1982"),
-      Models.RawCustomer("3", "Donald", "Glover", "1983")
-    )
+    val actualTable = spark.catalog.listTables().filter(_.name == "customer").head()
 
     ref.readAs[Models.RawCustomer]().collect() should contain theSameElementsAs expected
-
-    //TODO: Result is correct, matcher fails: investigate
-    //spark.catalog.listTables().collect() should contain (new org.apache.spark.sql.catalog.Table(
-    //name = "customer", database = "default", description = null, tableType = "EXTERNAL", isTemporary = false))
+    actualTable.toString() shouldBe expectedTable.toString()
   }
 
   override def beforeEach(): Unit = {

--- a/lighthouse-core/src/test/scala/be/dataminded/lighthouse/datalake/JdbcDataLinkTest.scala
+++ b/lighthouse-core/src/test/scala/be/dataminded/lighthouse/datalake/JdbcDataLinkTest.scala
@@ -3,11 +3,15 @@ package be.dataminded.lighthouse.datalake
 import be.dataminded.lighthouse.common.Database
 import be.dataminded.lighthouse.testing.SparkFunSuite
 import org.apache.spark.sql.SaveMode
-import org.scalatest.{BeforeAndAfterAll, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
 
 case class test_table(ID: java.lang.Integer, STR: String)
 
 class JdbcDataLinkTest extends SparkFunSuite with Matchers with BeforeAndAfterAll {
+  import spark.implicits._
+
+  private val extraOptions = Map("MODE" -> "MYSQL")
 
   override protected def beforeAll(): Unit = {
     Database.inMemory("test", Map("MODE" -> "MYSQL", "user" -> "sa", "DB_CLOSE_DELAY" -> "-1")).withConnection { con =>
@@ -24,11 +28,7 @@ class JdbcDataLinkTest extends SparkFunSuite with Matchers with BeforeAndAfterAl
     }
   }
 
-  val extraOptions = Map("MODE" -> "MYSQL")
-
   test("Reading JDBC datalink") {
-    import spark.implicits._
-
     val jdbcDataLink = new JdbcDataLink(
       url = "jdbc:h2:mem:test",
       username = "TEST",
@@ -43,8 +43,6 @@ class JdbcDataLinkTest extends SparkFunSuite with Matchers with BeforeAndAfterAl
   }
 
   test("Append JDBC datalink") {
-    import spark.implicits._
-
     val jdbcDataLink = new JdbcDataLink(
       url = "jdbc:h2:mem:test",
       username = "TEST",

--- a/lighthouse-core/src/test/scala/be/dataminded/lighthouse/datalake/LazyConfigTest.scala
+++ b/lighthouse-core/src/test/scala/be/dataminded/lighthouse/datalake/LazyConfigTest.scala
@@ -1,8 +1,9 @@
 package be.dataminded.lighthouse.datalake
 
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class LazyConfigTest extends FunSuite with Matchers {
+class LazyConfigTest extends AnyFunSuite with Matchers {
 
   test("LazyConfig should be evaluated every time is being called") {
     val test: LazyConfig[Long] = System.nanoTime

--- a/lighthouse-core/src/test/scala/be/dataminded/lighthouse/datalake/PackageTest.scala
+++ b/lighthouse-core/src/test/scala/be/dataminded/lighthouse/datalake/PackageTest.scala
@@ -2,9 +2,10 @@ package be.dataminded.lighthouse.datalake
 
 import java.util.Properties
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class PackageTest extends FunSpec with Matchers {
+class PackageTest extends AnyFunSpec with Matchers {
 
   describe("asProperties") {
     it("should convert a Scala to Java Properties implicitly") {

--- a/lighthouse-core/src/test/scala/be/dataminded/lighthouse/paramstore/FileParamStoreTest.scala
+++ b/lighthouse-core/src/test/scala/be/dataminded/lighthouse/paramstore/FileParamStoreTest.scala
@@ -2,9 +2,10 @@ package be.dataminded.lighthouse.paramstore
 
 import java.nio.file.NoSuchFileException
 
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class FileParamStoreTest extends FunSuite with Matchers {
+class FileParamStoreTest extends AnyFunSuite with Matchers {
 
   test("Can be used to retrieve a property from file") {
     //TODO: Implement

--- a/lighthouse-core/src/test/scala/be/dataminded/lighthouse/pipeline/PartitionedOrcSinkSpec.scala
+++ b/lighthouse-core/src/test/scala/be/dataminded/lighthouse/pipeline/PartitionedOrcSinkSpec.scala
@@ -2,9 +2,10 @@ package be.dataminded.lighthouse.pipeline
 
 import be.dataminded.lighthouse.testing.SharedSparkSession
 import better.files._
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class PartitionedOrcSinkSpec extends FunSpec with SharedSparkSession with Matchers {
+class PartitionedOrcSinkSpec extends AnyFunSpec with SharedSparkSession with Matchers {
 
   import spark.implicits._
 

--- a/lighthouse-core/src/test/scala/be/dataminded/lighthouse/pipeline/RichSparkFunctionsSpec.scala
+++ b/lighthouse-core/src/test/scala/be/dataminded/lighthouse/pipeline/RichSparkFunctionsSpec.scala
@@ -6,9 +6,11 @@ import be.dataminded.lighthouse.testing.SharedSparkSession
 import better.files._
 import org.apache.spark.sql.Dataset
 import org.apache.spark.storage.StorageLevel
-import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class RichSparkFunctionsSpec extends FunSpec with Matchers with SharedSparkSession with BeforeAndAfter {
+class RichSparkFunctionsSpec extends AnyFunSpec with Matchers with SharedSparkSession with BeforeAndAfter {
 
   import spark.implicits._
 
@@ -56,7 +58,7 @@ class RichSparkFunctionsSpec extends FunSpec with Matchers with SharedSparkSessi
     }
 
     it("can be be used as a Dataset") {
-      function.as[Int].run(spark) shouldBe a[Dataset[Int]]
+      function.as[Int].run(spark) shouldBe a[Dataset[_]]
     }
   }
 

--- a/lighthouse-core/src/test/scala/be/dataminded/lighthouse/pipeline/SingleFileSinkSpec.scala
+++ b/lighthouse-core/src/test/scala/be/dataminded/lighthouse/pipeline/SingleFileSinkSpec.scala
@@ -2,9 +2,11 @@ package be.dataminded.lighthouse.pipeline
 
 import be.dataminded.lighthouse.testing.SharedSparkSession
 import better.files._
-import org.scalatest.{BeforeAndAfterEach, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class SingleFileSinkSpec extends FunSpec with SharedSparkSession with Matchers with BeforeAndAfterEach {
+class SingleFileSinkSpec extends AnyFunSpec with SharedSparkSession with Matchers with BeforeAndAfterEach {
 
   import spark.implicits._
 

--- a/lighthouse-core/src/test/scala/be/dataminded/lighthouse/pipeline/SparkFunctionTest.scala
+++ b/lighthouse-core/src/test/scala/be/dataminded/lighthouse/pipeline/SparkFunctionTest.scala
@@ -5,9 +5,16 @@ import be.dataminded.lighthouse.testing.{DatasetComparer, SharedSparkSession}
 import better.files._
 import org.apache.spark.sql.functions.count
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
-import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class SparkFunctionTest extends FunSpec with Matchers with SharedSparkSession with DatasetComparer with BeforeAndAfter {
+class SparkFunctionTest
+    extends AnyFunSpec
+    with Matchers
+    with SharedSparkSession
+    with DatasetComparer
+    with BeforeAndAfter {
 
   import spark.implicits._
 
@@ -101,8 +108,8 @@ class SparkFunctionTest extends FunSpec with Matchers with SharedSparkSession wi
 
   describe("Demonstrate SparkFunctions using a SparkSession") {
 
-    val customerPath: String = File.resource("customers.csv").pathAsString
-    val ordersPath: String   = File.resource("orders.csv").pathAsString
+    val customerPath: String = Resource.getUrl("customers.csv").getPath()
+    val ordersPath: String   = Resource.getUrl("orders.csv").getPath()
 
     it("A SparkFunction can be used with a SparkSession") {
       val pipeline = SparkFunction { spark =>
@@ -218,13 +225,14 @@ class SparkFunctionTest extends FunSpec with Matchers with SharedSparkSession wi
 
       def dedup(persons: Dataset[RawPerson]): Dataset[RawPerson] = persons.distinct()
 
-      def normalize(persons: Dataset[RawPerson]) = SparkFunction { spark: SparkSession =>
-        import spark.implicits._
+      def normalize(persons: Dataset[RawPerson]): SparkFunction[Dataset[BasePerson]] = SparkFunction {
+        spark: SparkSession =>
+          import spark.implicits._
 
-        persons.map { raw =>
-          val tokens = raw.name.split(" ")
-          BasePerson(tokens(0), tokens(1), raw.age)
-        }
+          persons.map { raw =>
+            val tokens = raw.name.split(" ")
+            BasePerson(tokens(0), tokens(1), raw.age)
+          }
       }
 
       def returnBase(basePersons: Dataset[BasePerson]): Dataset[BasePerson] = basePersons

--- a/lighthouse-core/src/test/scala/be/dataminded/lighthouse/pipeline/TextSinkSpec.scala
+++ b/lighthouse-core/src/test/scala/be/dataminded/lighthouse/pipeline/TextSinkSpec.scala
@@ -2,9 +2,11 @@ package be.dataminded.lighthouse.pipeline
 
 import be.dataminded.lighthouse.testing.SharedSparkSession
 import better.files._
-import org.scalatest.{BeforeAndAfterEach, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class TextSinkSpec extends FunSpec with SharedSparkSession with Matchers with BeforeAndAfterEach {
+class TextSinkSpec extends AnyFunSpec with SharedSparkSession with Matchers with BeforeAndAfterEach {
 
   import spark.implicits._
 

--- a/lighthouse-demo/src/main/scala/be/dataminded/lighthouse/demo/AirplaneDatalake.scala
+++ b/lighthouse-demo/src/main/scala/be/dataminded/lighthouse/demo/AirplaneDatalake.scala
@@ -40,5 +40,5 @@ object AirplaneDatalake extends Datalake {
     )
   }
 
-  private def resource(path: String): String = File.resource(path).pathAsString
+  private def resource(path: String): String = Resource.getUrl(path).getPath()
 }

--- a/lighthouse-demo/src/test/scala/be/dataminded/lighthouse/demo/AirplanePipelineSpec.scala
+++ b/lighthouse-demo/src/test/scala/be/dataminded/lighthouse/demo/AirplanePipelineSpec.scala
@@ -4,14 +4,9 @@ import be.dataminded.lighthouse.testing.{DatasetComparer, SparkFunSuite}
 import better.files._
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types._
-import org.scalatest.{BeforeAndAfterAll, Matchers}
+import org.scalatest.matchers.should.Matchers
 
-class AirplanePipelineSpec
-    extends SparkFunSuite
-    with AirplanePipeline
-    with Matchers
-    with BeforeAndAfterAll
-    with DatasetComparer {
+class AirplanePipelineSpec extends SparkFunSuite with AirplanePipeline with Matchers with DatasetComparer {
 
   import spark.implicits._
 

--- a/lighthouse-testing/src/main/scala/be/dataminded/lighthouse/testing/SparkFunSuite.scala
+++ b/lighthouse-testing/src/main/scala/be/dataminded/lighthouse/testing/SparkFunSuite.scala
@@ -1,6 +1,7 @@
 package be.dataminded.lighthouse.testing
 
-import org.scalatest.{FunSuite, Tag}
+import org.scalatest.Tag
+import org.scalatest.funsuite.AnyFunSuite
 
 case object SparkTest            extends Tag("be.dataminded.lighthouse.testing.SparkTest")
 case object SparkIntegrationTest extends Tag("be.dataminded.lighthouse.testing.SparkIntegrationTest")
@@ -8,7 +9,7 @@ case object SparkIntegrationTest extends Tag("be.dataminded.lighthouse.testing.S
 /**
   * Base class for testing Spark-based applications.
   */
-class SparkFunSuite extends FunSuite with SharedSparkSession {
+class SparkFunSuite extends AnyFunSuite with SharedSparkSession {
 
   def test(name: String)(body: => Any /* Assertion */ ): Unit = {
     test(name, SparkTest) {
@@ -17,7 +18,7 @@ class SparkFunSuite extends FunSuite with SharedSparkSession {
   }
 }
 
-class SparkIntegrationFunSuite extends FunSuite with SharedSparkSession {
+class SparkIntegrationFunSuite extends AnyFunSuite with SharedSparkSession {
 
   def test(name: String)(body: => Any /* Assertion */ ): Unit = {
     test(name, SparkIntegrationTest) {

--- a/lighthouse-testing/src/test/scala/be/dataminded/lighthouse/testing/ColumnComparerSpec.scala
+++ b/lighthouse-testing/src/test/scala/be/dataminded/lighthouse/testing/ColumnComparerSpec.scala
@@ -1,9 +1,9 @@
 package be.dataminded.lighthouse.testing
 
 import org.apache.spark.sql.functions._
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class ColumnComparerSpec extends FunSpec with SharedSparkSession with ColumnComparer {
+class ColumnComparerSpec extends AnyFunSpec with SharedSparkSession with ColumnComparer {
 
   import spark.implicits._
 

--- a/lighthouse-testing/src/test/scala/be/dataminded/lighthouse/testing/DatasetComparerSpec.scala
+++ b/lighthouse-testing/src/test/scala/be/dataminded/lighthouse/testing/DatasetComparerSpec.scala
@@ -1,10 +1,10 @@
 package be.dataminded.lighthouse.testing
 
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-case class Person(name: String, age: Int)
+private case class Person(name: String, age: Int)
 
-class DatasetComparerSpec extends FunSpec with SharedSparkSession with DatasetComparer {
+class DatasetComparerSpec extends AnyFunSpec with SharedSparkSession with DatasetComparer {
 
   import spark.implicits._
 

--- a/lighthouse-testing/src/test/scala/be/dataminded/lighthouse/testing/SparkFunSuiteTest.scala
+++ b/lighthouse-testing/src/test/scala/be/dataminded/lighthouse/testing/SparkFunSuiteTest.scala
@@ -1,6 +1,6 @@
 package be.dataminded.lighthouse.testing
 
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 
 class SparkFunSuiteTest extends SparkFunSuite with Matchers {
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,8 +2,8 @@ import sbt._
 
 object Dependencies {
 
-  private val amazonSdkVersion = "1.11.477"
-  private val sparkVersion     = "2.4.0"
+  private val amazonSdkVersion = "1.11.659"
+  private val sparkVersion     = "2.4.4"
 
   val sparkCore = "org.apache.spark" %% "spark-core"  % sparkVersion % Provided
   val sparkSql  = "org.apache.spark" %% "spark-sql"   % sparkVersion % Provided
@@ -11,22 +11,22 @@ object Dependencies {
   val sparkMlib = "org.apache.spark" %% "spark-mllib" % sparkVersion % Provided
 
   val scopt          = "com.github.scopt"           %% "scopt"          % "3.7.1"
-  val typesafeConfig = "com.typesafe"               % "config"          % "1.3.3"
+  val typesafeConfig = "com.typesafe"               % "config"          % "1.4.0"
   val logback        = "ch.qos.logback"             % "logback-classic" % "1.2.3"
-  val scalaLogging   = "com.typesafe.scala-logging" %% "scala-logging"  % "3.9.0"
-  val cats           = "org.typelevel"              %% "cats-core"      % "1.5.0"
-  val betterFiles    = "com.github.pathikrit"       %% "better-files"   % "3.4.0"
+  val scalaLogging   = "com.typesafe.scala-logging" %% "scala-logging"  % "3.9.2"
+  val cats           = "org.typelevel"              %% "cats-core"      % "2.0.0"
+  val betterFiles    = "com.github.pathikrit"       %% "better-files"   % "3.8.0"
 
   // Database connectivity
-  val scalikejdbc = "org.scalikejdbc" %% "scalikejdbc" % "3.3.2"
-  val h2          = "com.h2database"  % "h2"           % "1.4.197" % Test
+  val scalikejdbc = "org.scalikejdbc" %% "scalikejdbc" % "3.4.0"
+  val h2          = "com.h2database"  % "h2"           % "1.4.200" % Test
 
   // Amazon AWS
   val awsSdkS3  = "com.amazonaws" % "aws-java-sdk-s3" % amazonSdkVersion % Provided
   val awsSdkSsm = "com.amazonaws" % "aws-java-sdk-ssm" % amazonSdkVersion % Provided
   val amazonSdk = Seq(awsSdkS3, awsSdkSsm)
 
-  val scalaTest        = "org.scalatest" %% "scalatest" % "3.0.5"
+  val scalaTest        = "org.scalatest" %% "scalatest" % "3.1.0"
   val testDependencies = Seq(scalaTest % Test, h2)
 
   val commonDependencies: Seq[ModuleID] =


### PR DESCRIPTION
- update spark dependency to the latest version;
- upgrade scalatest library to 3.1.0, implement changes required for the migration: new base classes, changed imports etc;
- bump other supporting libs;
- cleansing in the HiveDataLinkTest as a collateral effect;