### PR TITLE
Flush Spark's caches after the tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,11 @@ project/plugins/project/
 .history
 .cache
 .lib/
-.metals/
-.bloop/
 
 ### Scala template
+.metals/
+.bloop/
+project/metals.sbt
 *.class
 *.log
 

--- a/lighthouse-testing/src/main/scala/be/dataminded/lighthouse/testing/SparkFunSuite.scala
+++ b/lighthouse-testing/src/main/scala/be/dataminded/lighthouse/testing/SparkFunSuite.scala
@@ -1,7 +1,7 @@
 package be.dataminded.lighthouse.testing
 
-import org.scalatest.Tag
 import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.{BeforeAndAfterAll, Tag}
 
 case object SparkTest            extends Tag("be.dataminded.lighthouse.testing.SparkTest")
 case object SparkIntegrationTest extends Tag("be.dataminded.lighthouse.testing.SparkIntegrationTest")
@@ -9,20 +9,24 @@ case object SparkIntegrationTest extends Tag("be.dataminded.lighthouse.testing.S
 /**
   * Base class for testing Spark-based applications.
   */
-class SparkFunSuite extends AnyFunSuite with SharedSparkSession {
+abstract class SparkFunSuite extends AnyFunSuite with BeforeAndAfterAll with SharedSparkSession {
 
   def test(name: String)(body: => Any /* Assertion */ ): Unit = {
     test(name, SparkTest) {
       body
     }
   }
+
+  override def afterAll(): Unit = spark.catalog.clearCache()
 }
 
-class SparkIntegrationFunSuite extends AnyFunSuite with SharedSparkSession {
+abstract class SparkIntegrationFunSuite extends AnyFunSuite with BeforeAndAfterAll with SharedSparkSession {
 
   def test(name: String)(body: => Any /* Assertion */ ): Unit = {
     test(name, SparkIntegrationTest) {
       body
     }
   }
+
+  override def afterAll(): Unit = spark.catalog.clearCache()
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.6
+sbt.version=1.3.7


### PR DESCRIPTION
### Motivation

In our practice we have faced the OutOfMemory error caused by a high number of tests that execute pipelines with extensive use of Spark's persistence.

### What's been done:

- flush all caches after test-class execution;
- make the base testing classes abstract;
- update sbt to 1.7;